### PR TITLE
fix(action): set inputs to env to prevent injection attack

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,10 @@ runs:
       working-directory: ${{ inputs.directory }}
       run: |
         git add --all
-        git commit --message 'build: deploy ${{ github.sha }} to ${{ inputs.branch }}'
-        git push --force origin master:${{ inputs.branch }}
+        git commit --message "build: deploy ${{ github.sha }} to $BRANCH"
+        git push --force origin master:$BRANCH
+      env:
+        BRANCH: ${{ inputs.branch }}
 
     - name: Cleanup Git
       shell: bash


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(action): set inputs to env to prevent injection attack

## What is the current behavior?

`inputs.branch` is not escaped in the inline script step

## What is the new behavior?

`inputs.branch` is set as an environment variable in step

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation