### PR TITLE
feat(action): add optional input `token`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           directory: ${{ github.run_id }}
           branch: ${{ env.TEST_BRANCH }}
+          token: ${{ github.token }}
 
       - name: Checkout test branch
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ jobs:
 
 ## Usage
 
-**Basic:**
+Commit and push `dist` to the remote `gh-pages` branch:
 
 ```yaml
 - uses: remarkablemark/gitploy-action@v1
+  with:
+    directory: dist
+    branch: gh-pages
 ```
 
 See [action.yml](https://github.com/remarkablemark/gitploy-action/blob/master/action.yml)
@@ -67,6 +70,16 @@ See [action.yml](https://github.com/remarkablemark/gitploy-action/blob/master/ac
   with:
     directory: build
     branch: gh-pages
+```
+
+### `token`
+
+**Optional**: The GitHub token. Defaults to `GITHUB_TOKEN`:
+
+```yaml
+- uses: remarkablemark/gitploy-action@v1
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,12 @@ inputs:
   branch:
     description: The remote Git branch to deploy to.
     default: gh-pages
+    required: false
+
+  token:
+    description: The GitHub token.
+    default: ${{ github.token }}
+    required: false
 
 runs:
   using: composite
@@ -19,9 +25,14 @@ runs:
       working-directory: ${{ inputs.directory }}
       run: |
         git init --initial-branch master
-        git config user.name ${{ github.actor }}
-        git config user.email ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
-        git remote add origin https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}
+        git config user.name $ACTOR
+        git config user.email $ACTOR_ID+$ACTOR@users.noreply.github.com
+        git remote add origin https://$ACTOR:$GH_TOKEN@github.com/$REPOSITORY
+      env:
+        ACTOR: ${{ github.actor }}
+        ACTOR_ID: ${{ github.actor_id }}
+        REPOSITORY: ${{ github.repository }}
+        GH_TOKEN: ${{ inputs.token }}
 
     - name: Deploy directory to remote Git branch
       shell: bash


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(action): add optional input `token`

## What is the current behavior?

No way to set PAT

## What is the new behavior?

PAT can be set via input `token`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation