### PR TITLE
ci(github): set permissions content write to workflow `test.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 on: [push, pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): set permissions content write to workflow `test.yml`

## What is the current behavior?

`test.yml` fails with:

```
remote: Permission to remarkablemark/gitploy-action.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/remarkablemark/gitploy-action/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation